### PR TITLE
click fix

### DIFF
--- a/src/browser_source_interaction.py
+++ b/src/browser_source_interaction.py
@@ -65,7 +65,7 @@ def send_mouse_click_to_browser(
     y=0,
     button_type=obs.MOUSE_LEFT,
     mouse_up=False,
-    click_count=0,
+    click_count=1,
     key_modifiers=None,
 ):
     event = obs.obs_mouse_event()


### PR DESCRIPTION
Function click_at() from browser interaction example didn't work for me. Changing default `click_count` to `1` fixed this issue.